### PR TITLE
Fix: Display Thread without Comments

### DIFF
--- a/src/Applications/use_cases/GetThreadUseCase.js
+++ b/src/Applications/use_cases/GetThreadUseCase.js
@@ -8,13 +8,15 @@ class GetThreadUseCase {
   async execute (useCasePayload) {
     const thread = await this._threadRepository.find(useCasePayload.id)
     const comments = await this._commentRepository.findAllByThreadId(thread.id)
-    const replies = await this._replyRepository.findAllByCommentIds(
-      comments.map(comment => comment.id)
-    )
-    for (const comment of comments) {
-      comment.setReplies(replies[comment.id])
+    if (comments) {
+      const replies = await this._replyRepository.findAllByCommentIds(
+        comments.map(comment => comment.id)
+      )
+      for (const comment of comments) {
+        comment.setReplies(replies[comment.id])
+      }
+      thread.setComments(comments)
     }
-    thread.setComments(comments)
     return thread
   }
 }


### PR DESCRIPTION
**Why**
At the moment, there's error when user try to get thread without comment

**What**
- Updated related tests
- Added checker to handle undefined comment